### PR TITLE
Replaced references to PHE with NHS Digital

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.rubocop-https---raw-githubusercontent-com-NHSDigital-ndr-dev-support-master--rubocop-yml
 /.rubocop-https---raw-githubusercontent-com-PublicHealthEngland-ndr-dev-support-master--rubocop-yml
 /.bundle/
 /.yardoc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,1 @@
-inherit_from: 'https://raw.githubusercontent.com/PublicHealthEngland/ndr_dev_support/master/.rubocop.yml'
+inherit_from: 'https://raw.githubusercontent.com/NHSDigital/ndr_dev_support/master/.rubocop.yml'

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2011-2015 Public Health England
+Copyright (c) 2011-2022 NHS Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# NdrImport [![Build Status](https://github.com/publichealthengland/ndr_import/workflows/Test/badge.svg)](https://github.com/publichealthengland/ndr_import/actions?query=workflow%3Atest) [![Gem Version](https://badge.fury.io/rb/ndr_import.svg)](https://rubygems.org/gems/ndr_import) [![Documentation](https://img.shields.io/badge/ndr_import-docs-blue.svg)](https://www.rubydoc.info/gems/ndr_import)
-This is the Public Health England (PHE) National Disease Registers (NDR) Import ETL ruby gem, providing:
+# NdrImport [![Build Status](https://github.com/NHSDigital/ndr_import/workflows/Test/badge.svg)](https://github.com/NHSDigital/ndr_import/actions?query=workflow%3Atest) [![Gem Version](https://badge.fury.io/rb/ndr_import.svg)](https://rubygems.org/gems/ndr_import) [![Documentation](https://img.shields.io/badge/ndr_import-docs-blue.svg)](https://www.rubydoc.info/gems/ndr_import)
+This is the NHS Digital (NHSD) National Disease Registers (NDR) Import ETL ruby gem, providing:
 
 1. file import handlers for *extracting* data from delimited files (csv, pipe, tab, thorn), JSON Lines, .xls(x) spreadsheets, .doc(x) word documents, PDF, PDF AcroForms, XML, 7-Zip and Zip files.
 2. table mappers for *transforming* tabular and non-tabular data into key value pairs grouped by a common "klass".
@@ -49,7 +49,7 @@ end
 
 See `test/readme_test.rb` for a more complete working example.
 
-More information on the workings of the mapper are available in the [wiki](https://github.com/PublicHealthEngland/ndr_import/wiki).
+More information on the workings of the mapper are available in the [wiki](https://github.com/NHSDigital/ndr_import/wiki).
 
 ## Development
 
@@ -59,7 +59,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-1. Fork it ( https://github.com/PublicHealthEngland/ndr_import/fork )
+1. Fork it ( https://github.com/NHSDigital/ndr_import/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,7 +21,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   Google search results) and in your feed.xml site description.
 baseurl: "/ndr_import" # the subpath of your site, e.g. /blog
 # url: "https://" # the base hostname & protocol for your site, e.g. http://example.com
-github_username:  PublicHealthEngland
+github_username:  NHSDigital
 
 # Build settings
 markdown: kramdown

--- a/docs/inbuilt-cleaning-methods.md
+++ b/docs/inbuilt-cleaning-methods.md
@@ -4,7 +4,7 @@ title: Inbuilt Cleaning Methods
 permalink: /inbuilt-cleaning-methods/
 ---
 
-When creating mappings, there are a number of inbuilt cleaning methods (that are provided by the [NdrSupport gem](https://github.com/PublicHealthEngland/ndr_support)).
+When creating mappings, there are a number of inbuilt cleaning methods (that are provided by the [NdrSupport gem](https://github.com/NHSDigital/ndr_support)).
 
 These methods undertake standard cleaning of data when mapped into a field, with the rawtext value remaining unchanged.
 

--- a/docs/standard-yaml-mappings.md
+++ b/docs/standard-yaml-mappings.md
@@ -6,7 +6,7 @@ permalink: /standard-yaml-mappings/
 
 The YAML mapper can define a set of predefined standard mappings.
 
-The following example is the list of standard mappings used within PHE NDR:
+The following example is the list of standard mappings used within NHS Digital NDR:
 
 ```yaml
 surname:

--- a/gemfiles/Gemfile.rails52
+++ b/gemfiles/Gemfile.rails52
@@ -4,4 +4,4 @@ gemspec path: '..'
 
 gem 'activesupport', '~> 5.2.0'
 
-gem 'ndr_support', tag: 'v5.4.0', git: 'https://github.com/PublicHealthEngland/ndr_support'
+gem 'ndr_support', tag: 'v5.4.0', git: 'https://github.com/NHSDigital/ndr_support'

--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = []
   spec.summary       = 'NDR Import'
   spec.description   = 'NDR ETL Importer'
-  spec.homepage      = 'https://github.com/PublicHealthEngland/ndr_import'
+  spec.homepage      = 'https://github.com/NHSDigital/ndr_import'
   spec.license       = 'MIT'
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
This replaces all the references to Public Health England with NHS Digital, except for the `.github/CODEOWNERS` which remains the same, for now.