### PR TITLE
Store `significant_mapped_fields` hash in NdrImport::Tables

### DIFF
--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -12,7 +12,7 @@ module NdrImport
     def self.all_valid_options
       %w[canonical_name delimiter liberal_parsing filename_pattern file_password last_data_column
          tablename_pattern header_lines footer_lines format klass columns xml_record_xpath slurp
-         row_identifier]
+         row_identifier significant_mapped_fields]
     end
 
     def all_valid_options

--- a/test/non_tabular/table_test.rb
+++ b/test/non_tabular/table_test.rb
@@ -49,8 +49,8 @@ STR
   def test_all_valid_options
     valid_options = %w[
       canonical_name capture_end_line capture_start_line columns end_in_a_record end_line_pattern
-      filename_pattern file_password format klass remove_lines row_identifier start_in_a_record
-      start_line_pattern
+      filename_pattern file_password format klass remove_lines row_identifier
+      significant_mapped_fields start_in_a_record start_line_pattern
     ]
     assert_equal valid_options.sort,
                  NdrImport::NonTabular::Table.all_valid_options.sort


### PR DESCRIPTION
Store `significant_mapped_fields` hash with ` NdrImport::Table` meta data in YAML mappings.

The can then be used in record depulication in external systems