### PR TITLE
Xml enhancements

### DIFF
--- a/lib/ndr_import/file/xml.rb
+++ b/lib/ndr_import/file/xml.rb
@@ -15,19 +15,28 @@ module NdrImport
       private
 
       # Iterate through the file, yielding each 'xml_record_xpath' element in turn.
+      # Iterate through the file, yielding each 'xml_record_xpath' element in turn.
       def rows(&block)
         return enum_for(:rows) unless block
 
-        xpath = @options['xml_record_xpath']
-
         if @options['slurp']
-          doc = read_xml_file(@filename)
-          doc.xpath(xpath).each(&block)
+          record_elements(read_xml_file(@filename)).each(&block)
         else
+          xpath = "*/#{@options['xml_record_xpath']}"
           each_node(@filename, xpath, &block)
         end
       rescue StandardError => e
         raise("#{SafeFile.basename(@filename)} [#{e.class}: #{e.message}]")
+      end
+
+      def record_elements(doc)
+        if @options['pattern_match_record_xpath']
+          doc.root.children.find_all do |element|
+            element.name =~ Regexp.new(@options['xml_record_xpath'])
+          end
+        else
+          doc.root.xpath(@options['xml_record_xpath'])
+        end
       end
     end
     # Not all xml files may want to be registered, so 'xml' is not registered by design.

--- a/lib/ndr_import/non_tabular/table.rb
+++ b/lib/ndr_import/non_tabular/table.rb
@@ -17,7 +17,7 @@ module NdrImport
       include UTF8Encoding
 
       TABULAR_ONLY_OPTIONS = %w[delimiter last_data_column liberal_parsing tablename_pattern
-                                header_lines footer_lines xml_record_xpath slurp].freeze
+                                header_lines footer_lines slurp].freeze
 
       NON_TABULAR_OPTIONS = %w[capture_end_line capture_start_line start_line_pattern
                                end_line_pattern remove_lines start_in_a_record

--- a/lib/ndr_import/table.rb
+++ b/lib/ndr_import/table.rb
@@ -11,8 +11,8 @@ module NdrImport
 
     def self.all_valid_options
       %w[canonical_name delimiter liberal_parsing filename_pattern file_password last_data_column
-         tablename_pattern header_lines footer_lines format klass columns xml_record_xpath slurp
-         row_identifier significant_mapped_fields]
+         tablename_pattern header_lines footer_lines format klass columns slurp row_identifier
+         significant_mapped_fields]
     end
 
     def all_valid_options

--- a/lib/ndr_import/universal_importer_helper.rb
+++ b/lib/ndr_import/universal_importer_helper.rb
@@ -53,12 +53,14 @@ module NdrImport
         table_mapping = get_table_mapping(filename, nil)
 
         options = {
-          'unzip_path'       => unzip_path,
-          'col_sep'          => table_mapping.try(:delimiter),
-          'file_password'    => table_mapping.try(:file_password),
-          'liberal_parsing'  => table_mapping.try(:liberal_parsing),
-          'xml_record_xpath' => table_mapping.try(:xml_record_xpath),
-          'slurp'            => table_mapping.try(:slurp)
+          'unzip_path'                 => unzip_path,
+          'col_sep'                    => table_mapping.try(:delimiter),
+          'file_password'              => table_mapping.try(:file_password),
+          'liberal_parsing'            => table_mapping.try(:liberal_parsing),
+          'xml_record_xpath'           => table_mapping.try(:xml_record_xpath),
+          'slurp'                      => table_mapping.try(:slurp),
+          'yield_xml_record'           => table_mapping.try(:yield_xml_record),
+          'pattern_match_record_xpath' => table_mapping.try(:pattern_match_record_xpath)
         }
 
         tables = NdrImport::File::Registry.tables(filename, table_mapping.try(:format), options)

--- a/lib/ndr_import/vcf/table.rb
+++ b/lib/ndr_import/vcf/table.rb
@@ -6,7 +6,7 @@ module NdrImport
     # All other Table logic is inherited from `NdrImport::Table`
     class Table < ::NdrImport::Table
       def self.all_valid_options
-        super - %w[delimiter header_lines footer_lines xml_record_xpath]
+        super - %w[delimiter header_lines footer_lines]
       end
 
       def header_lines

--- a/lib/ndr_import/xml/column_mapping.rb
+++ b/lib/ndr_import/xml/column_mapping.rb
@@ -1,0 +1,67 @@
+module NdrImport
+  module Xml
+    # This class generates new XML column mappings where repeating columns/sections have been
+    # identified in the xml.
+    # This avoids need to need for mappings to verbosly define repeating columns/sections
+    class ColumnMapping
+      attr_accessor :existing_column, :unmapped_node_parts, :klass_increment, :xml_line, :klass
+
+      def initialize(existing_column, unmapped_node_parts, klass_increment, xml_line, klass)
+        @existing_column     = existing_column
+        @unmapped_node_parts = unmapped_node_parts
+        @klass_increment     = klass_increment
+        @xml_line            = xml_line
+        @klass               = klass
+      end
+
+      def call
+        new_column                              = existing_column.deep_dup
+        new_column['column']                    = unmapped_node_parts[:column_name]
+        new_column['xml_cell']['relative_path'] = unmapped_node_parts[:column_relative_path]
+
+        repeating_item = existing_column.dig('xml_cell', 'multiple')
+
+        # create unique rawtext names for repeating sections within a record
+        new_column['rawtext_name'] = new_rawtext_name(new_column) if repeating_item
+
+        return new_column if new_record_not_needed?(repeating_item)
+
+        new_column['klass'] = incremented_klass
+        new_column
+      end
+
+      private
+
+      # If a table level klass is defined, there is nothing to increment at the column level.
+      # Similarly, not all repeating sections/items require a separate record.
+      # No need to create new records for a single occurence of a repeating section
+      def new_record_not_needed?(repeating_item)
+        section_xpath    = existing_column.dig('xml_cell', 'section')
+        build_new_record = existing_column.dig('xml_cell', 'build_new_record')
+
+        klass.present? || build_new_record == false ||
+          (repeating_item && xml_line.xpath(section_xpath).one?)
+      end
+
+      def incremented_klass
+        if existing_column['klass'].is_a?(Array)
+          existing_column['klass'].map do |column_klass|
+            column_klass + "##{klass_increment}"
+          end
+        else
+          existing_column['klass'] + "##{klass_increment}"
+        end
+      end
+
+      # Append "_1", "_2" etc to repeating rawtext names within a single record
+      def new_rawtext_name(new_column)
+        existing_rawtext        = existing_column['rawtext_name'] || existing_column['column']
+        column_name_increment   = new_column['column'].match(/\[(\d+)\]\z/)
+        relative_path_increment = new_column.dig('xml_cell', 'relative_path').match(/\[(\d+)\]\z/)
+
+        rawtext_increment = column_name_increment || relative_path_increment
+        rawtext_increment ? existing_rawtext + "_#{rawtext_increment[1]}" : existing_rawtext
+      end
+    end
+  end
+end

--- a/lib/ndr_import/xml/masked_mappings.rb
+++ b/lib/ndr_import/xml/masked_mappings.rb
@@ -1,0 +1,70 @@
+module NdrImport
+  module Xml
+    # This class applies a do_not_capture mask to those mappings that do not relate to each klass.
+    # Overriding the NdrImport::Table method to avoid memoizing. This by design, column mappings
+    # can change if new mappings are added on the fly where repeating sections are present
+    class MaskedMappings
+      attr_accessor :klass, :augmented_columns
+
+      def initialize(klass, augmented_columns)
+        @klass             = klass
+        @augmented_columns = augmented_columns
+      end
+
+      def call
+        return { klass => augmented_columns } if klass.present?
+
+        masked_mappings = column_level_klass_masked_mappings
+
+        augmented_masked_mappings = masked_mappings
+        # Remove any masked klasses where additional columns mappings
+        # have been added for repeated sections
+        # e.g. SomeTestKLass column mappings are not needed if SomeTestKLass#1
+        # have been added
+        masked_mappings.each_key do |masked_key|
+          if masked_mappings.keys.any? { |key| key =~ /#{masked_key}#\d+/ }
+            augmented_masked_mappings.delete(masked_key)
+          end
+        end
+
+        augmented_masked_mappings
+      end
+
+      private
+
+      # This method duplicates the mappings and applies a do_not_capture mask to those that do not
+      # relate to this klass, returning the masked mappings
+      def mask_mappings_by_klass(klass)
+        augmented_columns.deep_dup.map do |mapping|
+          Array(mapping['klass']).flatten.include?(klass) ? mapping : { 'do_not_capture' => true }
+        end
+      end
+
+      def column_level_klass_masked_mappings
+        ensure_mappings_define_klass
+
+        # Loop through each klass
+        masked_mappings = {}
+        augmented_columns.pluck('klass').flatten.compact.uniq.each do |klass|
+          # Do not capture fields that relate to other klasses
+          masked_mappings[klass] = mask_mappings_by_klass(klass)
+        end
+        masked_mappings
+      end
+
+      # This method ensures that every column mapping defines a klass (unless it is a column that
+      # we do not capture). It is only used where a table level klass is not defined.
+      def ensure_mappings_define_klass
+        klassless_mappings = augmented_columns.
+                             select { |mapping| mapping.nil? || mapping['klass'].nil? }.
+                             reject { |mapping| mapping['do_not_capture'] }.
+                             map { |mapping| mapping['column'] || mapping['standard_mapping'] }
+
+        return if klassless_mappings.empty?
+
+        # All column mappings for the single item file require a klass definition.
+        raise "Missing klass for column(s): #{klassless_mappings.to_sentence}"
+      end
+    end
+  end
+end

--- a/lib/ndr_import/xml/table.rb
+++ b/lib/ndr_import/xml/table.rb
@@ -7,9 +7,16 @@ module NdrImport
     # attention has been made to use enumerables throughout to help with the
     # transformation of large quantities of data.
     class Table < ::NdrImport::Table
+      require 'ndr_import/xml/column_mapping'
+      require 'ndr_import/xml/masked_mappings'
+
+      XML_OPTIONS = %w[pattern_match_record_xpath xml_record_xpath yield_xml_record].freeze
+
       def self.all_valid_options
-        super - %w[delimiter header_lines footer_lines]
+        super - %w[delimiter header_lines footer_lines] + XML_OPTIONS
       end
+
+      attr_reader(*XML_OPTIONS)
 
       def header_lines
         0
@@ -24,26 +31,112 @@ module NdrImport
       # and fields for each mapped klass.
       def transform_line(line, index)
         return enum_for(:transform_line, line, index) unless block_given?
-
         raise 'Not an Nokogiri::XML::Element!' unless line.is_a? Nokogiri::XML::Element
 
-        validate_column_mappings(line)
+        augmented_masked_mappings = augment_and_validate_column_mappings_for(line)
 
-        xml_line = column_xpaths.map { |column_xpath| line.xpath(column_xpath).inner_text }
+        xml_line = xml_line_from(line)
 
-        masked_mappings.each do |klass, klass_mappings|
+        records_from_xml_line = []
+        augmented_masked_mappings.each do |klass, klass_mappings|
           fields = mapped_line(xml_line, klass_mappings)
+
           next if fields[:skip].to_s == 'true'.freeze
-          yield(klass, fields, index)
+
+          if yield_xml_record
+            records_from_xml_line << [klass, fields, index]
+          else
+            yield(klass, fields, index)
+          end
         end
+        yield(records_from_xml_line.compact) if yield_xml_record
       end
 
       private
 
+      def augment_and_validate_column_mappings_for(line)
+        augment_column_mappings_for(line)
+        validate_column_mappings(line)
+
+        NdrImport::Xml::MaskedMappings.new(@klass, @augmented_columns.deep_dup).call
+      end
+
+      # Add missing column mappings (and column_xpaths) where
+      # repeating sections / data items appear
+      def augment_column_mappings_for(line)
+        # Start with a fresh set of @augmented_columns for each line, adding new mappings as
+        # required for each `line`
+        @augmented_columns       = @columns.deep_dup
+        @augmented_column_xpaths = column_xpaths.deep_dup
+
+        unmapped_nodes(line).each do |unmapped_node|
+          existing_column = find_existing_column_for(unmapped_node.dup)
+          next unless existing_column
+
+          unmapped_node_parts   = unmapped_node_parts(unmapped_node)
+          klass_increment_match = unmapped_node.match(/\[(\d+)\]/)
+          raise "could not identify klass for #{unmapped_node}" unless klass_increment_match
+
+          new_column = NdrImport::Xml::ColumnMapping.new(existing_column, unmapped_node_parts,
+                                                         klass_increment_match[1], line,
+                                                         @klass).call
+          @augmented_columns << new_column
+          @augmented_column_xpaths << build_xpath_from(new_column)
+        end
+      end
+
+      def xml_line_from(line)
+        @augmented_column_xpaths.map do |column_xpath|
+          # Augmenting the column mappings should account for repeating sections/items
+          # TODO: Is this needed now that we removed "duplicated" klass mappings?
+          line.xpath(column_xpath).count > 1 ? '' : line.xpath(column_xpath).inner_text
+        end
+      end
+
+      def find_existing_column_for(unmapped_node)
+        # Remove any e.g. [2] which will be present on repeating sections
+        unmapped_node.gsub!(/\[\d+\]/, '')
+        unmapped_node_parts = unmapped_node_parts(unmapped_node)
+        columns.detect do |column|
+          column['column'] == unmapped_node_parts[:column_name] &&
+            column.dig('xml_cell', 'relative_path') == unmapped_node_parts[:column_relative_path] &&
+            column.dig('xml_cell', 'attribute') == unmapped_node_parts[:column_attribute]
+        end
+      end
+
+      def unmapped_node_parts(unmapped_node)
+        unmapped_node_parts       = unmapped_node.split('/')
+        unmapped_column_attribute = new_column_attribute_from(unmapped_node_parts)
+
+        { column_attribute: unmapped_column_attribute,
+          column_name: new_column_name_from(unmapped_node_parts, unmapped_column_attribute),
+          column_relative_path: new_relative_path_from(unmapped_node_parts,
+                                                       unmapped_column_attribute) }
+      end
+
+      def new_column_attribute_from(unmapped_node_parts)
+        unmapped_node_parts.last.starts_with?('@') ? unmapped_node_parts.last[1...] : nil
+      end
+
+      def new_column_name_from(unmapped_node_parts, unmapped_column_attribute)
+        unmapped_column_attribute.present? ? unmapped_node_parts[-2] : unmapped_node_parts.last
+      end
+
+      def new_relative_path_from(unmapped_node_parts, unmapped_column_attribute)
+        upper_limit = unmapped_column_attribute.present? ? -3 : -2
+        unmapped_node_parts.count > 1 ? unmapped_node_parts[0..upper_limit].join('/') : nil
+      end
+
       # Ensure every leaf is accounted for in the column mappings
       def validate_column_mappings(line)
-        missing_nodes = mappable_xpaths_from(line) - column_xpaths
+        missing_nodes = unmapped_nodes(line)
         raise "Unmapped data! #{missing_nodes}" unless missing_nodes.empty?
+      end
+
+      # Not memoized this by design, we want to re-calculate unmapped nodes after
+      # `@augmented_column_xpaths` have been augmented for each `line`
+      def unmapped_nodes(line)
+        mappable_xpaths_from(line) - (@augmented_column_xpaths || column_xpaths)
       end
 
       def column_name_from(column)
@@ -58,9 +151,12 @@ module NdrImport
         xpaths = []
 
         line.xpath('.//*[not(child::*)]').each do |node|
-          xpath = node.path.sub(line.path + '/', '')
-          xpaths << xpath
-          node.attributes.each_key { |key| xpaths << "#{xpath}/@#{key}" }
+          xpath = node.path.sub("#{line.path}/", '')
+          if node.attributes.any?
+            node.attributes.each_key { |key| xpaths << "#{xpath}/@#{key}" }
+          else
+            xpaths << xpath
+          end
         end
         xpaths
       end

--- a/test/file/xml_test.rb
+++ b/test/file/xml_test.rb
@@ -7,11 +7,11 @@ module NdrImport
     class XmlTest < ActiveSupport::TestCase
       def setup
         @file_path = SafePath.new('permanent_test_files').join('sample.xml')
-        @options   = { 'xml_record_xpath' => 'root/record' }
       end
 
       test 'should return enum of xml stream by default' do
-        handler = NdrImport::File::Xml.new(@file_path, nil, @options)
+        options = { 'xml_record_xpath' => 'record' }
+        handler = NdrImport::File::Xml.new(@file_path, nil, options)
         handler.expects(:read_xml_file).never
 
         rows = handler.send(:rows)
@@ -22,7 +22,23 @@ module NdrImport
       end
 
       test 'should slurp xml only if asked' do
-        handler = NdrImport::File::Xml.new(@file_path, nil, @options.merge('slurp' => true))
+        options = { 'xml_record_xpath' => 'record',
+                    'slurp' => true }
+        handler = NdrImport::File::Xml.new(@file_path, nil, options)
+        handler.expects(:each_node).never
+
+        rows = handler.send(:rows)
+
+        assert rows.is_a? Enumerator
+        assert(rows.all? { |row| row.is_a? Nokogiri::XML::Element })
+        assert_equal 2, rows.to_a.length
+      end
+
+      test 'should pattern match xpaths if asked ' do
+        options = { 'pattern_match_record_xpath' => true,
+                    'xml_record_xpath' => '\Arecord',
+                    'slurp' => true }
+        handler = NdrImport::File::Xml.new(@file_path, nil, options)
         handler.expects(:each_node).never
 
         rows = handler.send(:rows)

--- a/test/resources/repeating_section_sample.xml
+++ b/test/resources/repeating_section_sample.xml
@@ -1,0 +1,70 @@
+﻿<root>
+  <record>
+    <no_relative_path value="A value"/>
+    <no_path_or_att>Another value</no_path_or_att>
+    <demographics>
+      <demographics_1>AAA</demographics_1>
+      <address>
+        <address_line1>Address</address_line1>
+        <address_line1>Address 2</address_line1>
+      </address>
+      <demographics_2 code="03">Inner text</demographics_2>
+    </demographics>
+    <pathology>
+      <sample>
+        <pathology_date>2018-01-01</pathology_date>
+        <pathology_id>AAA</pathology_id>
+      </sample>
+      <sample>
+        <pathology_date>2019-01-01</pathology_date>
+        <pathology_id>BBB</pathology_id>
+      </sample>
+    </pathology>
+    <pathology>
+      <sample>
+        <pathology_date>2020-01-01</pathology_date>
+        <pathology_id>CCC</pathology_id>
+      </sample>
+    </pathology>
+  </record>
+  <record>
+    <demographics>
+      <address>
+        <address_line1>Address</address_line1>
+        <address_line1>Address 2</address_line1>
+      </address>
+      <demographics_2 code="03">Inner text</demographics_2>
+      <demographics_1>AAA</demographics_1>
+    </demographics>
+    <no_path_or_att><![CDATA[Another value]]></no_path_or_att>
+    <pathology>
+      <sample>
+        <pathology_date>2021-01-01</pathology_date>
+        <pathology_id>DDD</pathology_id>
+      </sample>
+      <sample>
+        <pathology_date>2022-01-01</pathology_date>
+        <pathology_id>EEE</pathology_id>
+      </sample>
+    </pathology>
+    <no_relative_path value="A value"/>
+  </record>
+  <record>
+    <demographics>
+      <address>
+        <address_line1>Address</address_line1>
+        <address_line1>Address 2</address_line1>
+      </address>
+      <demographics_2 code="03">Inner text</demographics_2>
+      <demographics_1>AAA</demographics_1>
+    </demographics>
+    <no_path_or_att><![CDATA[Another value]]></no_path_or_att>
+    <pathology>
+      <sample>
+        <pathology_date>2023-01-01</pathology_date>
+        <pathology_id>FFF</pathology_id>
+      </sample>
+    </pathology>
+    <no_relative_path value="A value"/>
+  </record>
+</root>

--- a/test/xml/column_mapping_test.rb
+++ b/test/xml/column_mapping_test.rb
@@ -1,0 +1,71 @@
+require 'test_helper'
+
+# This tests the NdrImport::Xml::ColumnMappingclass
+module Xml
+  class ColumnMappingTest < ActiveSupport::TestCase
+    def setup
+      file_path = SafePath.new('permanent_test_files').join('sample.xml')
+      options   = { 'xml_record_xpath' => 'record' }
+      handler   = NdrImport::File::Xml.new(file_path, nil, options)
+
+      rows = handler.send(:rows)
+      @xml_line = rows.first
+    end
+
+    test 'should generate column for repeating item within a record' do
+      existing_column = { 'column' => 'address_line1',
+                          'klass' => 'SomeTestKlass',
+                          'rawtext_name' => 'address',
+                          'xml_cell' => {
+                            'relative_path' => 'demographics/address',
+                            'multiple' => true,
+                            'build_new_record' => false
+                          },
+                          'mappings' => ['field' => 'test_field'] }
+
+      unmapped_node_parts = { column_attribute: nil, column_name: 'address_line1[1]',
+                              column_relative_path: 'demographics/address' }
+      klass_increment = '1'
+      klass = nil
+
+      expected_column = { 'column' => 'address_line1[1]',
+                          'klass' => 'SomeTestKlass',
+                          'rawtext_name' => 'address_1',
+                          'xml_cell' => {
+                            'relative_path' => 'demographics/address',
+                            'multiple' => true,
+                            'build_new_record' => false
+                          },
+                          'mappings' => [{ 'field' => 'test_field' }] }
+
+      new_column = NdrImport::Xml::ColumnMapping.new(existing_column, unmapped_node_parts,
+                                                     klass_increment, @xml_line, klass).call
+
+      assert_equal expected_column, new_column
+    end
+
+    test 'should generate a column with new klass' do
+      existing_column = { 'column' => 'pathology_date',
+                          'klass' => 'SomeTestKlass',
+                          'xml_cell' => {
+                            'relative_path' => 'pathology/sample', 'multiple' => true
+                          } }
+      unmapped_node_parts = { column_attribute: nil, column_name: 'pathology_date',
+                              column_relative_path: 'pathology[1]/sample[1]' }
+      klass_increment = '1'
+      klass = nil
+
+      expected_column = { 'column' => 'pathology_date',
+                          'klass' => 'SomeTestKlass#1',
+                          'xml_cell' => {
+                            'relative_path' => 'pathology[1]/sample[1]', 'multiple' => true
+                          },
+                          'rawtext_name' => 'pathology_date_1' }
+
+      new_column = NdrImport::Xml::ColumnMapping.new(existing_column, unmapped_node_parts,
+                                                     klass_increment, @xml_line, klass).call
+
+      assert_equal expected_column, new_column
+    end
+  end
+end

--- a/test/xml/masked_mappings_test.rb
+++ b/test/xml/masked_mappings_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+# This tests the NdrImport::Xml::MaskedMapping class
+module Xml
+  class MaskedMappingsTest < ActiveSupport::TestCase
+    def test_should_build_masked_mappings_with_column_specific_klasses
+      masked_mapping = NdrImport::Xml::MaskedMappings.new(nil, xml_column_mapping).call
+
+      assert_equal expected_masked_mappings, masked_mapping
+    end
+
+    def test_should_build_masked_mappings_with_table_level_klass
+      masked_mapping = NdrImport::Xml::MaskedMappings.new('SomeTestKlass', xml_column_mapping).call
+
+      assert_equal({ 'SomeTestKlass' => xml_column_mapping }, masked_mapping)
+    end
+
+    private
+
+    def xml_column_mapping
+      [
+        { 'column' => 'no_relative_path', 'klass' => 'SomeTestKlass#bob',
+          'xml_cell' => { 'relative_path' => '', 'attribute' => 'value' } },
+        { 'column' => 'no_relative_path', 'klass' => 'SomeTestKlass',
+          'rawtext_name' => 'no_relative_path_inner_text',
+          'xml_cell' => { 'relative_path' => '' } },
+        { 'column' => 'no_path_or_att', 'klass' => 'SomeTestKlass#1',
+          'xml_cell' => { 'relative_path' => '', 'attribute' => '' } },
+        { 'column' => 'demographics_1', 'klass' => 'SomeTestKlass#1',
+          'xml_cell' => { 'relative_path' => 'demographics' } },
+        { 'column' => 'demographics_2', 'klass' => 'SomeTestKlass#2',
+          'xml_cell' => { 'relative_path' => 'demographics', 'attribute' => 'code' } },
+        { 'column' => 'demographics_2', 'klass' => 'SomeTestKlass#2',
+          'rawtext_name' => 'demographics_2_inner_text',
+          'xml_cell' => { 'relative_path' => 'demographics' } }
+      ]
+    end
+
+    def expected_masked_mappings
+      { 'SomeTestKlass#bob' =>
+        [{ 'column' => 'no_relative_path', 'klass' => 'SomeTestKlass#bob',
+           'xml_cell' => { 'relative_path' => '', 'attribute' => 'value' } },
+         { 'do_not_capture' => true },
+         { 'do_not_capture' => true },
+         { 'do_not_capture' => true },
+         { 'do_not_capture' => true },
+         { 'do_not_capture' => true }],
+        'SomeTestKlass#1' =>
+        [{ 'do_not_capture' => true },
+         { 'do_not_capture' => true },
+         { 'column' => 'no_path_or_att', 'klass' => 'SomeTestKlass#1',
+           'xml_cell' => { 'relative_path' => '', 'attribute' => '' } },
+         { 'column' => 'demographics_1', 'klass' => 'SomeTestKlass#1',
+           'xml_cell' => { 'relative_path' => 'demographics' } },
+         { 'do_not_capture' => true },
+         { 'do_not_capture' => true }],
+        'SomeTestKlass#2' =>
+        [{ 'do_not_capture' => true },
+         { 'do_not_capture' => true },
+         { 'do_not_capture' => true },
+         { 'do_not_capture' => true },
+         { 'column' => 'demographics_2', 'klass' => 'SomeTestKlass#2',
+           'xml_cell' => { 'relative_path' => 'demographics', 'attribute' => 'code' } },
+         { 'column' => 'demographics_2', 'klass' => 'SomeTestKlass#2',
+           'rawtext_name' => 'demographics_2_inner_text',
+           'xml_cell' => { 'relative_path' => 'demographics' } }] }
+    end
+  end
+end

--- a/test/xml/table_test.rb
+++ b/test/xml/table_test.rb
@@ -5,7 +5,7 @@ module Xml
   class TableTest < ActiveSupport::TestCase
     def setup
       file_path = SafePath.new('permanent_test_files').join('sample.xml')
-      handler   = NdrImport::File::Xml.new(file_path, nil, 'xml_record_xpath' => 'root/record')
+      handler   = NdrImport::File::Xml.new(file_path, nil, 'xml_record_xpath' => 'record')
 
       @element_lines = handler.send(:rows)
     end
@@ -47,35 +47,107 @@ module Xml
       NdrImport::Xml::Table.new(klass: 'SomeTestKlass', slurp: true, columns: xml_column_mapping)
     end
 
+    def test_should_augment_columns_for_repeating_sections
+      file_path     = SafePath.new('permanent_test_files').join('repeating_section_sample.xml')
+      handler       = NdrImport::File::Xml.new(file_path, nil, 'xml_record_xpath' => 'record')
+      element_lines = handler.send(:rows)
+      table         = NdrImport::Xml::Table.new(columns: repeating_secion_xml_mapping)
+
+      expected_data = [
+        ['SomeTestKlass#1', { rawtext:
+           { 'pathology_date_1' => '2018-01-01', 'pathology_id_1' => 'AAA',
+             'pathology_date_2' => '2019-01-01', 'pathology_id_2' => 'BBB' } },
+         0],
+        ['SomeTestKlass#2', { rawtext:
+          { 'pathology_date' => '2020-01-01', 'pathology_id' => 'CCC' } },
+         0],
+        ['SomeTestKlass#1', { rawtext:
+          { 'pathology_date_1' => '2021-01-01', 'pathology_id_1' => 'DDD' } },
+         1],
+        ['SomeTestKlass#2', { rawtext:
+          { 'pathology_date_2' => '2022-01-01', 'pathology_id_2' => 'EEE' } },
+         1],
+        ['SomeTestKlass', { rawtext:
+          { 'no_relative_path' => 'A value', 'no_path_or_att' => 'Another value',
+            'demographics_1' => 'AAA', 'demographics_2' => '03',
+            'demographics_2_inner_text' => 'Inner text', 'address' => '',
+            'pathology_date' => '2023-01-01', 'pathology_id' => 'FFF',
+            'should_be_blank' => '', 'address_1' => 'Address', 'address_2' => 'Address 2' } },
+         2]
+      ]
+
+      # Trigger the augmentation logic
+      transformed_data = table.transform(element_lines).to_a
+
+      assert_equal expected_data, transformed_data
+    end
+
     private
 
     def xml_column_mapping
       [
-        { 'column' => 'no_relative_path',
+        { 'column' => 'no_relative_path', 'klass' => 'SomeTestKlass',
           'xml_cell' => { 'relative_path' => '', 'attribute' => 'value' } },
-        { 'column' => 'no_relative_path', 'rawtext_name' => 'no_relative_path_inner_text',
+        { 'column' => 'no_relative_path', 'klass' => 'SomeTestKlass',
+          'rawtext_name' => 'no_relative_path_inner_text',
           'xml_cell' => { 'relative_path' => '' } },
-        { 'column' => 'no_path_or_att',
+        { 'column' => 'no_path_or_att', 'klass' => 'SomeTestKlass',
           'xml_cell' => { 'relative_path' => '', 'attribute' => '' } },
-        { 'column' => 'demographics_1',
+        { 'column' => 'demographics_1', 'klass' => 'SomeTestKlass',
           'xml_cell' => { 'relative_path' => 'demographics' } },
-        { 'column' => 'demographics_2',
+        { 'column' => 'demographics_2', 'klass' => 'SomeTestKlass',
           'xml_cell' => { 'relative_path' => 'demographics', 'attribute' => 'code' } },
-        { 'column' => 'demographics_2', 'rawtext_name' => 'demographics_2_inner_text',
+        { 'column' => 'demographics_2', 'klass' => 'SomeTestKlass',
+          'rawtext_name' => 'demographics_2_inner_text',
           'xml_cell' => { 'relative_path' => 'demographics' } },
-        { 'column' => 'address_line1[1]', 'rawtext_name' => 'address1',
+        { 'column' => 'address_line1[1]', 'klass' => 'SomeTestKlass',
+          'rawtext_name' => 'address1',
           'xml_cell' => { 'relative_path' => 'demographics/address' } },
-        { 'column' => 'address_line1[2]', 'rawtext_name' => 'address2',
+        { 'column' => 'address_line1[2]', 'klass' => 'SomeTestKlass',
+          'rawtext_name' => 'address2',
           'xml_cell' => { 'relative_path' => 'demographics/address' } },
-        { 'column' => 'pathology_date_1',
+        { 'column' => 'pathology_date_1', 'klass' => 'SomeTestKlass',
           'xml_cell' => { 'relative_path' => 'pathology' } },
-        { 'column' => 'pathology_date_2',
+        { 'column' => 'pathology_date_2', 'klass' => 'SomeTestKlass',
           'xml_cell' => { 'relative_path' => 'pathology' } },
-        { 'column' => 'should_be_blank',
+        { 'column' => 'should_be_blank', 'klass' => 'SomeTestKlass',
           'xml_cell' => { 'relative_path' => 'not_present' } }
       ]
     end
 
+    def repeating_secion_xml_mapping
+      [
+        { 'column' => 'no_relative_path', 'klass' => 'SomeTestKlass',
+          'xml_cell' => { 'relative_path' => '', 'attribute' => 'value' } },
+        { 'column' => 'no_path_or_att', 'klass' => 'SomeTestKlass',
+          'xml_cell' => { 'relative_path' => '', 'attribute' => '' } },
+        { 'column' => 'demographics_1', 'klass' => 'SomeTestKlass',
+          'xml_cell' => { 'relative_path' => 'demographics' } },
+        { 'column' => 'demographics_2', 'klass' => 'SomeTestKlass',
+          'xml_cell' => { 'relative_path' => 'demographics', 'attribute' => 'code' } },
+        { 'column' => 'demographics_2', 'klass' => 'SomeTestKlass',
+          'rawtext_name' => 'demographics_2_inner_text',
+          'xml_cell' => { 'relative_path' => 'demographics' } },
+        { 'column' => 'address_line1', 'klass' => 'SomeTestKlass',
+          'rawtext_name' => 'address',
+          'xml_cell' =>
+            { 'relative_path' => 'demographics/address',
+              'multiple' => true,
+              'build_new_record' => false } },
+        { 'column' => 'pathology_date', 'klass' => 'SomeTestKlass',
+          'xml_cell' =>
+            { 'relative_path' => 'pathology/sample',
+              'multiple' => true } },
+        { 'column' => 'pathology_id', 'klass' => 'SomeTestKlass',
+          'xml_cell' =>
+            { 'relative_path' => 'pathology/sample',
+              'multiple' => true } },
+        { 'column' => 'should_be_blank', 'klass' => 'SomeTestKlass',
+          'xml_cell' => { 'relative_path' => 'not_present' } }
+      ]
+    end
+
+    # These columns are made on the fly by the Table
     def partial_xml_column_mapping
       [
         { 'column' => 'no_relative_path',

--- a/test/xml/table_test.rb
+++ b/test/xml/table_test.rb
@@ -147,7 +147,6 @@ module Xml
       ]
     end
 
-    # These columns are made on the fly by the Table
     def partial_xml_column_mapping
       [
         { 'column' => 'no_relative_path',


### PR DESCRIPTION
This PR extends the existing XML importing logic by:

- Allowing `xml_record_xpath` in `NdrImport::Xml::Table` to be a regexp
- Optionally yielding the records created within a `xml_record_xpath`, so that they're grouped under the same `index`
- Creating column mappings automatically to handle repeating sections/data items so that the mappings do not need to be written verbosely. 


**Augmented column mappings:**

`NdrImport::Xml::Table`  identifies any xpaths within the XML `line` that do not have an appropriate column mapping and augments the mappings with additional columns.

e.g. given this xml:

```
<pathology>
  <sample>
    <pathology_date>2018-01-01</pathology_date>
    <pathology_id>AAA</pathology_id>
  </sample>
  <sample>
    <pathology_date>2019-01-01</pathology_date>
    <pathology_id>BBB</pathology_id>
  </sample>
</pathology>
<pathology>
  <sample>
    <pathology_date>2020-01-01</pathology_date>
    <pathology_id>CCC</pathology_id>
  </sample>
</pathology>    
```

...and these column mappings:
```
[{ 'column' => 'pathology_date', 'klass' => 'SomeTestKlass',
   'xml_cell' =>
     { 'relative_path' => 'pathology/sample',
       'multiple' => true } },
 { 'column' => 'pathology_id', 'klass' => 'SomeTestKlass',
   'xml_cell' =>
     { 'relative_path' => 'pathology/sample',
       'multiple' => true } }]
```

...these additional column mappings are added automatically, creating a new record for each `<pathology>` section:

```
    { 'column' => 'pathology_date', 'klass' => 'SomeTestKlass#1',
      'xml_cell' => 
        { 'relative_path' => 'pathology[1]/sample[1]',
          'multiple' => true },
      'rawtext_name' => 'pathology_date_1' },
    {'column' => 'pathology_id', 'klass' => 'SomeTestKlass#1',
      'xml_cell' => 
        { 'relative_path' => 'pathology[1]/sample[1]',
          'multiple' => true },
      'rawtext_name' => 'pathology_id_1'},
    { 'column' => 'pathology_date', 'klass' => 'SomeTestKlass#1',
      'xml_cell' => 
        { 'relative_path' => 'pathology[1]/sample[2]',
          'multiple' => true },
      'rawtext_name' => 'pathology_date_2' },
    { 'column' => 'pathology_id', 'klass' => 'SomeTestKlass#1', 
      'xml_cell' => 
        { 'relative_path' => 'pathology[1]/sample[2]',
          'multiple' => true },
      'rawtext_name' => 'pathology_id_2' },
    { 'column' => 'pathology_date', 'klass' => 'SomeTestKlass#2',
      'xml_cell' => 
        { 'relative_path' => 'pathology[2]/sample',
          'multiple' => true },
      'rawtext_name' => 'pathology_date' },
    { 'column' => 'pathology_id', 'klass' => 'SomeTestKlass#2',
      'xml_cell' => 
        { 'relative_path' => 'pathology[2]/sample',
          'multiple' => true },
      'rawtext_name' => 'pathology_id' }
```

These column mappings are created per `line` of XML data, with any previously generated column mappings removed so that  mappings generated previously do not pollute the mappings for the current `line`.

Once the additional column mappings are added, the xml `line` is validated to ensure all nodes have an appropiate column mapping.
