### PR TITLE
Replace unsupported seven_zip_ruby gem with seven-zip fork.

### DIFF
--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ooxml_decrypt'
   spec.add_dependency 'pdf-reader', '~> 2.1'
   spec.add_dependency 'roo-xls'
-  spec.add_dependency 'seven_zip_ruby', '~> 1.3'
+  spec.add_dependency 'seven-zip', '~> 1.4'
   spec.add_dependency 'spreadsheet', '1.2.6'
 
   spec.required_ruby_version = '>= 3.0'


### PR DESCRIPTION
The `seven_zip_ruby` gem is unsupported, causing failures with GitHub Actions on Ruby 3.1.
`seven-zip` is a forked gem which supports more recent compilers.