### PR TITLE
Bump to v11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## [Unreleased]
 =======
+*no unreleased changes*
+
+## 11.0.0 / 2023-10-27
+### Added
 * XML enhancements
-* Move from seven_zip_ruby to seven-zip
+### Fixed
+* Replace unsupported seven_zip_ruby gem with seven-zip fork
 
 ## 10.3.0 / 2023-09-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 *no unreleased changes*
 
 ## 11.0.0 / 2023-10-27
-### Added
-* XML enhancements
+### Changed
+* XML enhancements. Breaking change, the enhancements are not backward compatible
 ### Fixed
 * Replace unsupported seven_zip_ruby gem with seven-zip fork
 

--- a/lib/ndr_import/version.rb
+++ b/lib/ndr_import/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 # This stores the current version of the NdrImport gem
 module NdrImport
-  VERSION = '10.3.0'
+  VERSION = '11.0.0'
 end


### PR DESCRIPTION
The XML enhancements introduce a breaking change that is not backward compatiable, so this is a major version bump.