### PR TITLE
Support Rails 7.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
         gemfile:
           - gemfiles/Gemfile.rails61
           - gemfiles/Gemfile.rails70
+          - gemfiles/Gemfile.rails71
         exclude:
           # rails 7.0 requires ruby >= 2.7
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 =======
-*no unreleased changes*
+### Added
+* Support Rails 7.1
 
 ## 11.0.1 / 2023-10-30
 ### Fixed

--- a/gemfiles/Gemfile.rails71
+++ b/gemfiles/Gemfile.rails71
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 7.1.0'

--- a/ndr_import.gemspec
+++ b/ndr_import.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activemodel'
-  spec.add_dependency 'activesupport', '>= 6.1', '< 7.1'
+  spec.add_dependency 'activesupport', '>= 6.1', '< 7.2'
   spec.add_dependency 'ndr_support', '>= 5.3.2', '< 6'
 
   spec.add_dependency 'rubyzip', '~> 2.0'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 SimpleCov.start
 
+require 'active_support'
 require 'active_support/test_case'
 require 'active_support/core_ext/string'
 require 'ndr_support/safe_path'


### PR DESCRIPTION
Support Rails 7.1 and include it in the test matrix.

There are a number of Rails deprecation warnings triggered by this. I've tried but can't immediately find an easy way to fix them. For now, I'd rather we had Rails 7.1 support, and we can come back later to find good fixes for them (probably easier after we drop Rails 6.1 support).