### PR TITLE
Resolve Rails 7 deprecation messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 =======
-*no unreleased changes*
+### Fixed
+* Resolve Rails 7 deprecation warnings
 
 ## 11.0.1 / 2023-10-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =======
 ### Fixed
 * Resolve Rails 7 deprecation warnings
+* Fix XML parsing with latest `nokogiri` 1.16.0
 
 ## 11.0.1 / 2023-10-30
 ### Fixed

--- a/lib/ndr_import/file/excel.rb
+++ b/lib/ndr_import/file/excel.rb
@@ -46,7 +46,7 @@ module NdrImport
       end
 
       def cast_excel_datetime_as_date(raw_value)
-        raw_value.to_s(:db)
+        raw_value.to_formatted_s(:db)
       end
 
       private

--- a/lib/ndr_import/helpers/file/excel.rb
+++ b/lib/ndr_import/helpers/file/excel.rb
@@ -32,7 +32,7 @@ module NdrImport
         end
 
         def cast_excel_datetime_as_date(raw_value)
-          raw_value.to_s(:db)
+          raw_value.to_formatted_s(:db)
         end
 
         # Iterate through the file table by table, yielding each one in turn.

--- a/lib/ndr_import/helpers/file/xml.rb
+++ b/lib/ndr_import/helpers/file/xml.rb
@@ -22,6 +22,11 @@ module NdrImport
           doc = nil
 
           escaping_control_chars_if_necessary(preserve_control_chars, file_data) do
+            if Nokogiri::XML('<?xml version="1.0" encoding="UTF-16"?><body/>').
+               errors.first.message.match?(/Blank needed here\z/)
+              # Nokogiri 1.16.0 workaround for UTF-16 data.
+              file_data.sub!('UTF-16', 'UTF-8')
+            end
             doc = Nokogiri::XML(file_data, &:huge)
             doc.encoding = 'UTF-8'
             emulate_strict_mode_fatal_check!(doc)


### PR DESCRIPTION
This resolves deprecation warnings in Rails 7.0 about using `#to_s(:db)`.

It also fixes errors with the latest Nokogiri 1.16.0, when handling UTF-16 files which we've loaded and converted to UTF-8.