### PR TITLE
XML table should gracefully handle empty nodes/elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 =======
-* no unreleased changes*
+* XML table should not expect column mappings for empty nodes/elements
 
 ## 11.0.2 / 2024-02-06
 ### Fixed

--- a/lib/ndr_import/xml/table.rb
+++ b/lib/ndr_import/xml/table.rb
@@ -169,7 +169,7 @@ module NdrImport
         xpaths = []
 
         line.xpath('.//*[not(child::*)]').each do |node|
-          next unless populated_leaf?(node)
+          next unless populated?(node)
 
           xpath = node.path.sub("#{line.path}/", '')
           if node.attributes.any?
@@ -181,7 +181,7 @@ module NdrImport
         xpaths
       end
 
-      def populated_leaf?(node)
+      def populated?(node)
         node.element_children.empty? &&
           !node.is_a?(Nokogiri::XML::Comment) && !node.text? && !node.cdata? &&
           !(node.attributes.empty? && node.content.strip.blank?)

--- a/lib/ndr_import/xml/table.rb
+++ b/lib/ndr_import/xml/table.rb
@@ -169,6 +169,8 @@ module NdrImport
         xpaths = []
 
         line.xpath('.//*[not(child::*)]').each do |node|
+          next unless populated_leaf?(node)
+
           xpath = node.path.sub("#{line.path}/", '')
           if node.attributes.any?
             node.attributes.each_key { |key| xpaths << "#{xpath}/@#{key}" }
@@ -177,6 +179,12 @@ module NdrImport
           end
         end
         xpaths
+      end
+
+      def populated_leaf?(node)
+        node.element_children.empty? &&
+          !node.is_a?(Nokogiri::XML::Comment) && !node.text? && !node.cdata? &&
+          !(node.attributes.empty? && node.content.strip.blank?)
       end
 
       def build_xpath_from(column)

--- a/test/resources/sample_with_empty_nodes.xml
+++ b/test/resources/sample_with_empty_nodes.xml
@@ -1,0 +1,12 @@
+﻿<root>
+  <record>
+    <no_relative_path value="A value"/>
+    <no_path_or_att>Another value</no_path_or_att>
+    <demographics>
+      <demographics_1>AAA</demographics_1>
+      <demographics_2 code="03">Inner text</demographics_2>
+      <address></address>
+    </demographics>
+    <pathology></pathology>
+  </record>
+</root>


### PR DESCRIPTION
`Xml::Table` checks that every xpath from an xml record is accounted for in column mappings, this means that empty nodes/sections require a column mapping

Example xml:

```
<root>
  <record>
    <no_relative_path value="A value"/>
    <no_path_or_att>Another value</no_path_or_att>
    <demographics>
      <demographics_1>AAA</demographics_1>
      <demographics_2 code="03">Inner text</demographics_2>
    </demographics>
    <pathology></pathology>
  </record>
</root>
```

The `pathology` section is empty, but would require a column mapping, that is set to `do_not_capture`, so that `Xml::Table ` is happy the xpath is accounted for.

column mapping for `pathology`:

```
{ 'column' => 'pathology', 'klass' => 'SomeTestKlass',
   'xml_cell' => { 'relative_path' => '' },
   ' do_not_capture' => true }
```

This PR only requires a column mapping where the section/mode/elment is populated, and would mean the above column mapping wouldn't be required 