### PR TITLE
Add column/data zipping functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 =======
-* no unreleased changes *
+* Column zipping functionality *
 
 ## 11.2.0 / 2024-04-10
 ### Added

--- a/docs/yaml-mapping-user-guide.md
+++ b/docs/yaml-mapping-user-guide.md
@@ -13,3 +13,4 @@ add_to_nav: true
 6. [Non Tabular Mappings](non-tabular-mappings.md)
 7. [Date Formats](date-formats.md)
 8. [XML mappings](xml-mappings.md)
+9. [Zipped Field Mapping](priority-field-mapping.md)

--- a/docs/zipped-field-mapping.md
+++ b/docs/zipped-field-mapping.md
@@ -39,7 +39,7 @@ This would result in:
 
 Reversing the `zip_order` in the mapping would result in:
 ```
-{ "zipped_field"=>[["dog", "species""], ["brown", "colour"], ["4", "legs"]],
+{ "zipped_field"=>[["dog", "species"], ["brown", "colour"], ["4", "legs"]],
    :rawtext=>{"title"=>"species,colour,legs", "value"=>"dog,brown,4"}}
 ```
 

--- a/docs/zipped-field-mapping.md
+++ b/docs/zipped-field-mapping.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Zipped Field Mapping
+permalink: /zipped-field-mapping/
+---
+
+Multiple incoming columns can be mapped to a single field, zipping array values (split from strings) together.
+
+The mapper will identify  all the columns that have been mapped to a given `field`, with their `zip_order` and `split_char`. It will then take the string value for each of these and split them using the given `split_char`, resulting in an array of arrays.
+
+Then using the `zip_order`, it'll take the first array and zip in the remaining arrays in their `zip_order`
+
+Example mapping:
+
+---
+    - column: title
+      mappings:
+      - field: zipped_field
+        zip_order: 1
+        split_char: ","
+    - column: value
+      mappings:
+      - field: zipped_field
+        zip_order: 2
+
+Example data:
+
+```
+"title","value"
+"species,colour,legs","dog,brown,4"
+```
+
+This would result in:
+
+```
+{ "zipped_field"=>[["species", "dog"], ["colour", "brown"], ["legs", "4"]],
+   :rawtext=>{"title"=>"species,colour,legs", "value"=>"dog,brown,4"}}
+```
+
+Reversing the `zip_order` in the mapping would result in:
+```
+{ "zipped_field"=>[["dog", "species""], ["brown", "colour"], ["4", "legs"]],
+   :rawtext=>{"title"=>"species,colour,legs", "value"=>"dog,brown,4"}}
+```
+

--- a/lib/ndr_import/mapper.rb
+++ b/lib/ndr_import/mapper.rb
@@ -151,7 +151,7 @@ module NdrImport::Mapper
           data[field][:values][field_mapping[Strings::ORDER] - 1] = value
         elsif field_mapping[Strings::PRIORITY]
           data[field][:values][field_mapping[Strings::PRIORITY]] = value
-        elsif field_mapping[Strings::ZIP_ORDER]
+        elsif field_zippable?(field_mapping, data[field])
           data[field][:split_char] ||= field_mapping[Strings::SPLIT_CHAR]
           data[field][:zipped_values][field_mapping[Strings::ZIP_ORDER] - 1] = value
         else
@@ -174,7 +174,7 @@ module NdrImport::Mapper
           values = values.map(&:presence)
           values.compact! if field_data[:compact]
           values.join(field_data[:join])
-        elsif field_data[:zipped_values].present?
+        elsif zipped_values.present?
           values = zipped_values.map { |value| value.split(field_data[:split_char]) }
           values.first.zip(*values[1..])
         else
@@ -184,6 +184,12 @@ module NdrImport::Mapper
 
     attributes[:rawtext] = rawtext # Assign last
     attributes
+  end
+
+  def field_zippable?(field_mapping, data_field)
+    return false if field_mapping[Strings::ZIP_ORDER].blank?
+
+    data_field[:split_char].present? || field_mapping[Strings::SPLIT_CHAR].present?
   end
 
   def mapped_value(original_value, field_mapping)

--- a/lib/ndr_import/mapper.rb
+++ b/lib/ndr_import/mapper.rb
@@ -121,9 +121,10 @@ module NdrImport::Mapper
       rawtext[rawtext_column_name] = raw_value
 
       next unless column_mapping.key?(Strings::MAPPINGS)
+
       column_mapping[Strings::MAPPINGS].each do |field_mapping|
         # create a duplicate of the raw value we can manipulate
-        original_value = raw_value ? raw_value.dup : nil
+        original_value = raw_value&.dup
 
         replace_before_mapping(original_value, field_mapping)
         value = mapped_value(original_value, field_mapping)


### PR DESCRIPTION
This PR adds column zipping functionality to the mapper, where 2 (or more) columns can have their string values split by a given `split_char` and then be zipped together in a prescribed order.

E.g. given this csv data

```
"title","value"
"species,colour,legs","dog,brown,4"
```

and this data:

```yaml
    - column: title
      mappings:
      - field: zipped_field
        zip_order: 1
        split_char: ","
    - column: value
      mappings:
      - field: zipped_field
        zip_order: 2
```

This mapped_line would be produced:

```
{ "zipped_field"=>[["species", "dog"], ["colour", "brown"], ["legs", "4"]],
   :rawtext=>{"title"=>"species,colour,legs", "value"=>"dog,brown,4"}}
```