### PR TITLE
Bugfix/concurrent ruby rails70 testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
+### Fixed
+* Fix CSV parsing bug
+
 ### Added
 * Column zipping functionality *
 * Capturing Column name *

--- a/gemfiles/Gemfile.rails61
+++ b/gemfiles/Gemfile.rails61
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'activesupport', '~> 6.1.0'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/gemfiles/Gemfile.rails70
+++ b/gemfiles/Gemfile.rails70
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'activesupport', '~> 7.0.0'
+
+# Latest concurrent-ruby breaks Rails < 7.1. See https://github.com/rails/rails/issues/54260
+gem 'concurrent-ruby', '1.3.4'

--- a/lib/ndr_import/helpers/file/delimited.rb
+++ b/lib/ndr_import/helpers/file/delimited.rb
@@ -28,7 +28,7 @@ module NdrImport
         end
 
         # Iterate through the file line by line, yielding each one in turn.
-        def delimited_rows(path, col_sep = nil, liberal = false)
+        def delimited_rows(path, col_sep = nil, liberal = false) # rubocop:disable Style/OptionalBooleanParameter
           return enum_for(:delimited_rows, path, col_sep, liberal) unless block_given?
 
           safe_path = SafeFile.safepath_to_string(path)
@@ -36,7 +36,7 @@ module NdrImport
 
           # By now, we know `options` should let us read the whole
           # file succesfully; if there are problems, we should crash.
-          CSV.foreach(safe_path, options.delete(:mode), **options) do |line|
+          CSV.foreach(safe_path, options[:mode], **options.except(:mode)) do |line|
             yield line.map(&:to_s)
           end
         end


### PR DESCRIPTION
Fix CSV parsing bug. (We were mutating the options hash to remove the `:mode`, but sometimes this meant we were mutating the cached result, and then passing in a `nil` mode subsequently. This bug has been revealed by extra checks in the latest `csv` library.)

Fix `concurrent-ruby` version to 1.3.4 for older Rails versions
