### PR TITLE
Improve performance when handling large XML files with significant column augmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* no unreleased changes
+### Enhancement
+* Performance improvements for XML mask mappings
 
 ## 11.3.0/ 2025-02-11
 ### Fixed


### PR DESCRIPTION
The `Xml::Table` class attempts to augment column_mappings based on the data where there might be repeating sections/fields. It does this for each `line`, and so can be memory/compute intensive. 

This PR takes a number of small steps to improve the efficiency, focusing on the `Xml::MaskedMappings` class.

Before this PR, ~1250 repeating sections took ~95 seconds for mapping augmentation. This PR gets that down to ~5.8 seconds.

Some of the small steps...
- Frozen object reuse e.g. `DO_NOT_CAPTURE_MAPPING = { 'do_not_capture' => true }.freeze`
- Using `deep_dup` only when needed
- Pre-allocating Arrays and hash with exact size to avoid resizing operations
- Direct array assignment to avoid intermediate objects (e.g. `.map`)
- Where possible, using O(1) lookups instead of O(n) searches
- Use `Set`s